### PR TITLE
Project ReadMe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
+# Project Secrets
+impakt/settings/config.py
+
+# Filesystem
+*.swp
+
 # Javascript
 node_modules/
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,33 @@
 # ImpaktWebsite
 Repository for the Impakt Website and API
+
+# Setup
+1. Create a new project directory
+    `mkdir -p ~/Projects/ImpaktWebsite`
+    `cd ~/Projects/ImpaktWebsite`
+2. Create and activate virtual environment for the project
+    `python3 -m venv venv`
+    `source venv/bin/activate`
+3. Install project requirements
+    `pip install -r requirements.txt`
+4. Install postgresql locally (instructions varying depending on platform)
+5. Configure your local postgres database. Replace "myname" with... your name.
+    `sudo su - postgres`
+    `psql`
+    `CREATE USER myname;`
+    `ALTER USER myname WITH SUPERUSER;`
+    `ALTER GROUP postgres ADD USER myname;`
+    `ALTER USER myname WITH PASSWORD 'mypassword';`
+6. Create a config.py file to store project credentials. The file is in the project gitignore, but take care to never commit this file to Git.
+    `cp impakt/settings/sample_config.py impakt/settings/config.py`
+    `nano impakt/settings/config.py`
+7. Install node and npm for frontend dependency and build process management.
+8. Install frontend dependencies
+    `npm install`
+9. Run project migrations
+    `python manage.py migrate`
+10. Run your local runserver and visit localhost:8000 to confirm that you're all set up!
+    `python manage.py runserver`
+
+And you're done!
+

--- a/impakt/settings/base.py
+++ b/impakt/settings/base.py
@@ -13,9 +13,19 @@ https://docs.djangoproject.com/en/2.0/ref/settings/
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 import os
 
+try:
+    from .config import CONFIG
+except ImportError:
+    msg = (
+        "You're missing a config.py file. This should contain secret project "
+        "settings as well as local configuration settings. Add this file "
+        "within your settings directory, alongside base.py"
+    )
+    raise Exception(msg)
+
 PROJECT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 BASE_DIR = os.path.dirname(PROJECT_DIR)
-
+SECRET_KEY = CONFIG['SECRET_KEY']
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/2.0/howto/deployment/checklist/
@@ -91,8 +101,10 @@ WSGI_APPLICATION = 'impakt.wsgi.application'
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
+        'ENGINE': 'django.db.backends.postgresql',
+        'NAME': CONFIG['DB_NAME'],
+        'USER': CONFIG['DB_USER'],
+        'PASSWORD': CONFIG['DB_PASSWORD'],
     }
 }
 
@@ -132,20 +144,18 @@ USE_TZ = True
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/2.0/howto/static-files/
-
+STATICFILES_DIRS = [
+    os.path.join(PROJECT_DIR, 'static'),
+]
 STATICFILES_FINDERS = [
     'django.contrib.staticfiles.finders.FileSystemFinder',
     'django.contrib.staticfiles.finders.AppDirectoriesFinder',
 ]
-
-STATICFILES_DIRS = [
-    os.path.join(PROJECT_DIR, 'static'),
-]
-
-STATIC_ROOT = os.path.join(BASE_DIR, 'static')
+STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.ManifestStaticFilesStorage'
+STATIC_ROOT = CONFIG['STATIC_ROOT']
 STATIC_URL = '/static/'
 
-MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
+MEDIA_ROOT = CONFIG['MEDIA_ROOT']
 MEDIA_URL = '/media/'
 
 

--- a/impakt/settings/sample_config.py
+++ b/impakt/settings/sample_config.py
@@ -1,0 +1,16 @@
+# Configuration file containing settings that shouldn't be in version control
+CONFIG = {
+    # Django Project Settings
+    'DEBUG':
+    'SECRET_KEY': 
+
+    # Database
+    'DB_HOST':
+    'DB_NAME':
+    'DB_PASSWORD':
+    'DB_USER':
+
+    # MEDIA & STATIC FILES
+    'MEDIA_ROOT':
+    'STATIC_ROOT':
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
 Django>=2.0,<2.1
 wagtail>=2.0,<2.1
+psycopg2-binary==2.7.4
+psycopg2==2.7.4
+psycopg2-binary==2.7.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 Django>=2.0,<2.1
 wagtail>=2.0,<2.1
-psycopg2-binary==2.7.4
 psycopg2==2.7.4
 psycopg2-binary==2.7.4


### PR DESCRIPTION
For ticket #3 

**Changes**
Writing setup instructions for how to get going with the project. Also, tying the python settings.py files into the config.py file. 

The config.py file is a take on having a .env file read by a library such as Django Environ. My main gripe with those is that we can't use that to set variable types (bugs are caused by having inconsistently applied quotes, or forgetting whether MAX_COUNT=12 will be interpreted as a string or not. 

Instead, creating a config.py file at that location allows us to keep secrets out of version control while keeping python syntax, variables, and functions available to the local configuration settings.

The dictionary syntax (and not using `dict.get()` within the settings files) allows us to encounter type errors whenever a variable isn't set, ensuring that misconfigured settings fail loudly.

**Manual Testing**
Bring down this branch locally and confirm that your project doesn't initialize until you've created the config.py file in the proper location. After you've filled in the variables according to your system setup, confirm that the app runs properly.